### PR TITLE
ci: configure Release job to publish npm package

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,10 +46,17 @@ jobs:
     if: ${{ needs.pre-commit.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.5.1
         with:
           node-version: 14.18.1
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@shahradr"
       - name: Release
         run: npx semantic-release@v18.0.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+@shahradr:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "cdktf",
+  "name": "@shahradr/azure-sql-server",
   "version": "1.0.0",
   "main": "main.js",
   "types": "main.ts",
   "license": "MIT",
-  "private": true,
+  "repository": "https://github.com/ShahradR/azure-sql-server.git",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "restricted"
+  },
+  "private": false,
   "scripts": {
     "get": "cdktf get",
     "build": "tsc",


### PR DESCRIPTION
Configure the GitHub Actions workflow to publish this package to the npm
registry associated to this repository after a release is completed.