### PR TITLE
feat: add Key Vault firewall rules

### DIFF
--- a/__tests__/mssql-construct.test.ts
+++ b/__tests__/mssql-construct.test.ts
@@ -180,6 +180,17 @@ describe("given a synthesized Terraform configuration", () => {
           ],
         });
       });
+
+      it("should only allow Azure Services access to the secret", () => {
+        expect.assertions(1);
+
+        expect(construct).toHaveResourceWithProperties(KeyVault, {
+          network_acls: {
+            default_action: "Deny",
+            bypass: "AzureServices",
+          },
+        });
+      });
     });
 
     describe("a Key Vault Secret for the SQL Server database login", () => {

--- a/src/mssql-construct.ts
+++ b/src/mssql-construct.ts
@@ -61,6 +61,10 @@ export class MsSQLConstruct extends Construct {
       skuName: "standard",
       tenantId: config.tenantId,
       accessPolicy: config.keyVaultAccessPolicy,
+      networkAcls: {
+        defaultAction: "Deny",
+        bypass: "AzureServices",
+      },
     });
 
     this.mssqlDatabasePasswordSecret = new KeyVaultSecret(


### PR DESCRIPTION
Add a firewall rule to the Azure Key Vault secret created by this construct to deny access to the secret from all sources except other Azure services.