### PR TITLE
ci: add Node authentication token to release job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,6 +46,7 @@ jobs:
     if: ${{ needs.pre-commit.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
Add the NODE_AUTH_TOKEN environment variable to allow the release job to authenticate to GitHub Packages, and publish this construct as a Node package.