### PR TITLE
Configure Checkov security scans against the Terraform template

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,4 +8,4 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends vim python3-pip
 
-RUN pip install pre-commit detect-secrets
+RUN pip install pre-commit detect-secrets checkov

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,30 @@ jobs:
           name: coverage
           path: coverage/
 
+  bridgecrew:
+    name: Scan IaC code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install Node packaged
+        run: npm install -g cdktf-cli@next && npm install -g ts-node@10.9.1 && npm install
+      - name: Synthesize Terraform template and convert to HCL2
+        run: $GITHUB_WORKSPACE/src/resources/hcl2-convert.sh
+      - name: Run Bridgecrew scan
+        id: Bridgecrew
+        uses: bridgecrewio/bridgecrew-action@v1.1653.0
+        with:
+          api-key: ${{ secrets.BRIDGECREW_API_KEY }}
+          directory: /home/runner/work/azure-sql-server/azure-sql-server/cdktf.out/
+          soft_fail: true
+          framework: terraform
+          output_format: cli
+          quiet: false
+          download_external_modules: true
+
   vale:
     name: Run Vale
     runs-on: ubuntu-latest
@@ -42,7 +66,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, tests, vale]
+    needs: [pre-commit, tests, vale, bridgecrew]
     if: ${{ needs.pre-commit.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cdktf.json
+++ b/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "typescript",
-  "app": "npx ts-node src/stack.ts",
+  "app": "npx ts-node src/mssql-test-stack.ts",
   "projectId": "19ac8912-27a4-4c17-9e1a-1fb85eaa6548",
   "sendCrashReports": "true",
   "terraformProviders": ["hashicorp/azurerm@~> 3.24"],

--- a/src/resources/hcl2-convert.sh
+++ b/src/resources/hcl2-convert.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+cdktf get
+cdktf synth
+echo $(cat $GITHUB_WORKSPACE/cdktf.out/stacks/cdktf/cdk.tf.json | jq -f $GITHUB_WORKSPACE/src/resources/jq-filter.jq) > $GITHUB_WORKSPACE/cdktf.out/stacks/cdktf/cdk.tf.json
+
+curl -SsL https://github.com/kvz/json2hcl/releases/download/v0.0.6/json2hcl_v0.0.6_linux_amd64 \
+  | sudo tee /usr/local/bin/json2hcl > /dev/null && sudo chmod 755 /usr/local/bin/json2hcl && json2hcl -version
+
+json2hcl < $GITHUB_WORKSPACE/cdktf.out/stacks/cdktf/cdk.tf.json > $GITHUB_WORKSPACE/cdktf.out/cdk.tf
+
+terraform_dir=$(mktemp -d -t terraform-XXXXXX)
+
+pushd $terraform_dir
+    wget https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip
+    unzip terraform_0.12.31_linux_amd64.zip
+    ./terraform init $GITHUB_WORKSPACE/cdktf.out/stacks/cdktf
+    ./terraform 0.12upgrade --yes --force $GITHUB_WORKSPACE/cdktf.out/
+    echo $GITHUB_WORKSPACE/cdktf.out/
+popd

--- a/src/resources/jq-filter.jq
+++ b/src/resources/jq-filter.jq
@@ -1,0 +1,13 @@
+walk(
+    if type == "object" then
+        with_entries(
+            select(
+                (.value != null and .key != "sensitive" and .key != "terraform" and .key != "provider")
+                and
+                (.key | test("\/\/") | not)
+            )
+        )
+    else
+        .
+    end
+)


### PR DESCRIPTION
Configure the project to run Checkov scans against the generated Terraform templates as part of the CI pipeline and publish the results to the Bridgecrew Cloud.

Because the Terraform CDK does not generate HCL2 templates, a script was also added to the project to translate the synthesized JSON template to HCL2, allowing Checkov to read it.